### PR TITLE
endpoint가 1로 시작하지 않는 경우 main 스위치가 동작하지 않고 child 스위치가 하나 더 생성되는 문제 수정

### DIFF
--- a/zigbee-multi-switch/src/init.lua
+++ b/zigbee-multi-switch/src/init.lua
@@ -53,7 +53,7 @@ end
 --------------------------------------------------
 
 local function find_child(parent, endpoint)
-	if endpoint == 1 then
+	if endpoint == parent.fingerprinted_endpoint_id then
 		return parent
 	else
 		return parent:get_child_by_parent_assigned_key(string.format("%02X", endpoint))
@@ -77,7 +77,7 @@ local function create_child_devices(driver, device)
 	end
 	
 	for i, ep in pairs(ep_array) do
-		if ep ~= 1 then
+		if ep ~= device.fingerprinted_endpoint_id then
 			if find_child(device, ep) == nil then
 				local metadata = {
 					type = "EDGE_CHILD",
@@ -97,12 +97,12 @@ end
 --------------------------------------------------
 
 function switch_on_handler(driver, device, command)
-	local ep = (device.network_type == st_device.NETWORK_TYPE_CHILD) and tonumber(device.parent_assigned_child_key, 16) or 1
+	local ep = (device.network_type == st_device.NETWORK_TYPE_CHILD) and tonumber(device.parent_assigned_child_key, 16) or device.fingerprinted_endpoint_id
 	device:send(zcl_clusters.OnOff.server.commands.On(device):to_endpoint(ep))
 end
 
 function switch_off_handler(driver, device, command)
-	local ep = (device.network_type == st_device.NETWORK_TYPE_CHILD) and tonumber(device.parent_assigned_child_key, 16) or 1
+	local ep = (device.network_type == st_device.NETWORK_TYPE_CHILD) and tonumber(device.parent_assigned_child_key, 16) or device.fingerprinted_endpoint_id
 	device:send(zcl_clusters.OnOff.server.commands.Off(device):to_endpoint(ep))
 end
 


### PR DESCRIPTION
안녕하세요.

제가 가지고 있는 Zemismart 스위치에서 endpoint가 1로 시작하지 않는 경우 발생하는 문제를 수정해 보았어요.

제가 가지고 있는 Zemismart는 endpoint가 11, 12 로 이루어져 있어, main 스위치는 동작하지 않고 child 스위치가 2개 생성되는 문제가 있어요.

```
2022-12-10T05:05:32.514242995+00:00 TRACE Zigbee Multi Switch by iquix  Zigbee Device: 9ada2fd9-e180-4946-9fe5-ebef841d029c
Manufacturer: FeiBit Model: FNB56-ZSW02LX2.0
        [12]: Basic, Groups, Identify, OnOff, Scenes, Level     [11]: Basic, Groups, Identify, OnOff, Scenes, TouchlinkCommissioning, Level
```

제 기기에서는 정상 동작하는 것을 확인 하기는 했는데, 이렇게 수정하는 것이 맞을 지 한번 보시면 좋을 것 같아요.